### PR TITLE
Check include/exclude regex against `path/file` (and not just `file`)

### DIFF
--- a/fswatch.go
+++ b/fswatch.go
@@ -99,7 +99,6 @@ type gowatch struct {
 
 // Check if file matches
 func (this *gowatch) match(file string) bool {
-	file = filepath.Base(file)
 	for _, rule := range this.reExclude {
 		if rule.MatchString(file) {
 			return false


### PR DESCRIPTION
Hello,

I'm using `go generate` to build some .go files and need to exclude those files, yet still watch similar named files in another directory.

At the moment the code checks the regex's against the `file` segment only, so I either need to totally ignore all files of the same name as the ones generated, otherwise I'll get an infinite build loop.