### PR TITLE
Pass config file as a flag, using YAML as fallback

### DIFF
--- a/fswatch.go
+++ b/fswatch.go
@@ -472,6 +472,7 @@ func InitFWConfig() {
 
 func main() {
 	version := flag.Bool("version", false, "Show version")
+	configfile := flag.String("config", FWCONFIG_YAML, "Show version")
 	flag.Parse()
 
 	if *version {
@@ -483,7 +484,7 @@ func main() {
 	var fwc FWConfig
 	var err error
 	if subCmd == "" {
-		fwc, err = readFWConfig(FWCONFIG_JSON, FWCONFIG_YAML)
+		fwc, err = readFWConfig(*configfile, FWCONFIG_JSON)
 		if err == nil {
 			subCmd = "start"
 		} else {


### PR DESCRIPTION
It seems common to trigger different actions for the files being watched. 

For a golang webapp, you may watch `go` and `tmpl` file extensions and use `go run` as the command. 
For stylesheets, you may watch `sass` file extension and use `gosass` as the command.

It would be convenient to be able to pass the configurations file as a parameter to fswatch, so we could define different strategies.

We actually forked a previous version a while ago to achive that : https://github.com/klacointe/fswatch/commit/a34d3fced59ed6e504964c2c9da29b2e52b342d9

Here's a new one.