### PR TITLE
Implemented stop timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ triggers:
   shell: true
   cmd: go test -v
   delay: 100ms
+  stop_timeout:1s
   signal: "KILL"
   kill_signal: "SIGTERM"
 watch_paths:

--- a/fswatch.go
+++ b/fswatch.go
@@ -211,7 +211,7 @@ func fixFWConfig(in FWConfig) (out FWConfig, err error) {
 			return
 		}
 		if trigger.StopTimeout == "" {
-			outTg.Delay = "500ms"
+			outTg.StopTimeout = "500ms"
 		}
 		outTg.stopTimeoutDuration, err = time.ParseDuration(outTg.StopTimeout)
 		if err != nil {


### PR DESCRIPTION
I am using fswatch with docker-compose and was getting some error because of this line of code at **fswatch.go**.

> case <-time.After(500 * time.Millisecond): // todo: timeout need to be set in conf.

I had to implement the timeout because stopping gracefully docker-compose can take a while..