### PR TITLE
update go-fsnotify to fsnotify

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,10 @@ _test
 *.[568vq]
 [568vq].out
 
+
+.idea
+
+
 *.cgo1.go
 *.cgo2.c
 _cgo_defun.c

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,36 +1,36 @@
 {
-	"ImportPath": "github.com/codeskyblue/fswatch",
-	"GoVersion": "go1.6",
-	"GodepVersion": "v74",
-	"Deps": [
-		{
-			"ImportPath": "github.com/codeskyblue/dockerignore",
-			"Rev": "de82dee623d9207f906d327172149cba50427a88"
-		},
-		{
-			"ImportPath": "github.com/codeskyblue/kexec",
-			"Rev": "b7e1983cb3267c8862794eacf39b14386dfa441f"
-		},
-		{
-			"ImportPath": "github.com/go-fsnotify/fsnotify",
-			"Comment": "v1.3.1",
-			"Rev": "a8a77c9133d2d6fd8334f3260d06f60e8d80a5fb"
-		},
-		{
-			"ImportPath": "github.com/gobuild/log",
-			"Rev": "f1f03dc733eb8acf247f889dd103ee1de1a06caa"
-		},
-		{
-			"ImportPath": "github.com/google/shlex",
-			"Rev": "6f45313302b9c56850fc17f99e40caebce98c716"
-		},
-		{
-			"ImportPath": "golang.org/x/sys/unix",
-			"Rev": "a646d33e2ee3172a661fc09bca23bb4889a41bc8"
-		},
-		{
-			"ImportPath": "gopkg.in/yaml.v2",
-			"Rev": "f7716cbe52baa25d2e9b0d0da546fcf909fc16b4"
-		}
-	]
+  "ImportPath": "github.com/codeskyblue/fswatch",
+  "GoVersion": "go1.6",
+  "GodepVersion": "v74",
+  "Deps": [
+    {
+      "ImportPath": "github.com/codeskyblue/dockerignore",
+      "Rev": "de82dee623d9207f906d327172149cba50427a88"
+    },
+    {
+      "ImportPath": "github.com/codeskyblue/kexec",
+      "Rev": "b7e1983cb3267c8862794eacf39b14386dfa441f"
+    },
+    {
+      "ImportPath": "github.com/fsnotify/fsnotify",
+      "Comment": "v1.3.1",
+      "Rev": "c2828203cd70a50dcccfb2761f8b1f8ceef9a8e9"
+    },
+    {
+      "ImportPath": "github.com/gobuild/log",
+      "Rev": "f1f03dc733eb8acf247f889dd103ee1de1a06caa"
+    },
+    {
+      "ImportPath": "github.com/google/shlex",
+      "Rev": "6f45313302b9c56850fc17f99e40caebce98c716"
+    },
+    {
+      "ImportPath": "golang.org/x/sys/unix",
+      "Rev": "a646d33e2ee3172a661fc09bca23bb4889a41bc8"
+    },
+    {
+      "ImportPath": "gopkg.in/yaml.v2",
+      "Rev": "f7716cbe52baa25d2e9b0d0da546fcf909fc16b4"
+    }
+  ]
 }

--- a/fswatch.go
+++ b/fswatch.go
@@ -21,10 +21,10 @@ import (
 
 	ignore "github.com/codeskyblue/dockerignore"
 	"github.com/codeskyblue/kexec"
-	"github.com/go-fsnotify/fsnotify"
+	"github.com/fsnotify/fsnotify"
 	"github.com/gobuild/log"
 	"github.com/google/shlex"
-	yaml "gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v2"
 )
 
 const (


### PR DESCRIPTION
Change your dependencies from `github.com/go-fsnotify/fsnotify` to `github.com/fsnotify/fsnotify`

according with [https://github.com/go-fsnotify/fsnotify](url)

go get is failing because of this particular repo.