### PR TITLE
Update README.md to resolve error--> line 11: could not find expected…

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ triggers:
   shell: true
   cmd: go test -v
   delay: 100ms
-  stop_timeout:1s
+  stop_timeout: 1s
   signal: "KILL"
   kill_signal: "SIGTERM"
 watch_paths:


### PR DESCRIPTION
When trying to run the sample code from README.md , got an error line 11: could not find expected ':', because there is no  space after colon(":") .